### PR TITLE
Board activation logic and title hint

### DIFF
--- a/packages/example-dev/src/App.vue
+++ b/packages/example-dev/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <HeadUp class="head-up">
-    <Board title="Cell components #1">
+    <Board id="b1" title="Cell components #1">
       <Cell title="Cell #1" padded>
         <div>First section</div>
         <div>Second section</div>
@@ -11,7 +11,7 @@
       </Cell>
       <Cell/>
     </Board>
-    <Board title="Cell components #2">
+    <Board id="b2" title="Cell components #2">
       <Cell padded>
         <div>First section</div>
         <div>Second section</div>

--- a/packages/example/src/App.vue
+++ b/packages/example/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <HeadUp class="head-up">
-    <Board title="Cell components #1">
+    <Board id="b1" title="Cell components #1">
       <Cell title="Cell #1" padded>
         <div>First section</div>
         <div>Second section</div>
@@ -11,7 +11,7 @@
       </Cell>
       <Cell/>
     </Board>
-    <Board title="Cell components #2">
+    <Board id="b2" title="Cell components #2">
       <Cell padded>
         <div>First section</div>
         <div>Second section</div>

--- a/packages/head-up/package-lock.json
+++ b/packages/head-up/package-lock.json
@@ -1566,6 +1566,14 @@
 				"normalize-path": "^2.1.1"
 			}
 		},
+		"apparatus": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
+			"integrity": "sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==",
+			"requires": {
+				"sylvester": ">= 0.0.8"
+			}
+		},
 		"append-transform": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
@@ -1670,6 +1678,11 @@
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
+		},
+		"articles": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/articles/-/articles-0.2.2.tgz",
+			"integrity": "sha512-S3Y4MPp+LD/l0HHm/4yrr6MoXhUkKT98ZdsV2tkTuBNywqUXEtvJT+NBO3KTSQEttc5EOwEJe2Xw8cZ9TI5Hrw=="
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -8790,6 +8803,11 @@
 			"dev": true,
 			"optional": true
 		},
+		"nanoid": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.0.tgz",
+			"integrity": "sha512-SG2qscLE3iM4C0CNzGrsAojJHSVHMS1J8NnvJ31P1lH8P0hGHOiafmniNJz6w6q7vuoDlV7RdySlJgtqkFEVtQ=="
+		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -8807,6 +8825,16 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
+			}
+		},
+		"natural": {
+			"version": "0.1.29",
+			"resolved": "http://registry.npmjs.org/natural/-/natural-0.1.29.tgz",
+			"integrity": "sha1-WaN6bNhtVekEtlbTudpD/S3J4Eo=",
+			"requires": {
+				"apparatus": ">= 0.0.6",
+				"sylvester": ">= 0.0.12",
+				"underscore": ">=1.3.1"
 			}
 		},
 		"natural-compare": {
@@ -10898,6 +10926,11 @@
 			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
 			"dev": true
 		},
+		"prng-well1024a": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prng-well1024a/-/prng-well1024a-1.0.1.tgz",
+			"integrity": "sha1-Bejtkj5OorP3ivXulPBWtNXPqyQ="
+		},
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -11079,6 +11112,14 @@
 			"requires": {
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
+			}
+		},
+		"randy": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/randy/-/randy-1.5.1.tgz",
+			"integrity": "sha1-59wIag7Li+99ZzVmQs0qM/liRlw=",
+			"requires": {
+				"prng-well1024a": "~1.0.0"
 			}
 		},
 		"range-parser": {
@@ -11760,6 +11801,24 @@
 				}
 			}
 		},
+		"sentencer": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/sentencer/-/sentencer-0.1.5.tgz",
+			"integrity": "sha1-HDURWBoAsiNhJ/+yH94X9PSGWeI=",
+			"requires": {
+				"articles": "~0.2.1",
+				"lodash": "~2.4.1",
+				"natural": "~0.1.28",
+				"randy": "~1.5.1"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "2.4.2",
+					"resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+				}
+			}
+		},
 		"serialize-javascript": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
@@ -11893,6 +11952,14 @@
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
 			"dev": true
+		},
+		"shortid": {
+			"version": "2.2.14",
+			"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.14.tgz",
+			"integrity": "sha512-4UnZgr9gDdA1kaKj/38IiudfC3KHKhDc1zi/HSxd9FQDR0VLwH3/y79tZJLsVYPsJgIjeHjqIWaWVRJUj9qZOQ==",
+			"requires": {
+				"nanoid": "^2.0.0"
+			}
 		},
 		"sigmund": {
 			"version": "1.0.1",
@@ -12516,6 +12583,11 @@
 				"util.promisify": "~1.0.0"
 			}
 		},
+		"sylvester": {
+			"version": "0.0.21",
+			"resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz",
+			"integrity": "sha1-KYexzivS84sNzio0OIiEv6RADqc="
+		},
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -13037,6 +13109,11 @@
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
 			}
+		},
+		"underscore": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+			"integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",

--- a/packages/head-up/package.json
+++ b/packages/head-up/package.json
@@ -15,6 +15,7 @@
     "ally.js": "1.4.1",
     "focus-visible": "4.1.5",
     "lodash": "4.17.11",
+    "sentencer": "0.1.5",
     "vue-awesome": "3.2.0",
     "vue-shortkey": "3.1.6"
   },

--- a/packages/head-up/src/components/Board/Board.test.js
+++ b/packages/head-up/src/components/Board/Board.test.js
@@ -11,6 +11,9 @@ const commonSettings = {
 test('render empty', () => {
   const wrapper = shallowMount(Board, {
     ...commonSettings,
+    propsData: {
+      id: '1',
+    },
   });
   expect(wrapper).toMatchSnapshot();
 });
@@ -19,6 +22,7 @@ test('render normal', () => {
   const wrapper = shallowMount(Board, {
     ...commonSettings,
     propsData: {
+      id: '1',
       title: 'Board title',
     },
     slots: {
@@ -32,6 +36,7 @@ test('render as thumbnail', () => {
   const wrapper = shallowMount(Board, {
     ...commonSettings,
     propsData: {
+      id: '1',
       title: 'Board title',
       isThumb: true,
     },
@@ -46,6 +51,7 @@ test('render in edit mode', () => {
   const wrapper = shallowMount(Board, {
     ...commonSettings,
     propsData: {
+      id: '1',
       title: 'Board title',
       editable: true,
     },

--- a/packages/head-up/src/components/Board/Board.vue
+++ b/packages/head-up/src/components/Board/Board.vue
@@ -43,7 +43,7 @@ export default {
   props: {
     id: {
       type: String,
-      default: '',
+      required: true,
     },
     isThumb: {
       type: Boolean,

--- a/packages/head-up/src/components/Cell/Cell.vue
+++ b/packages/head-up/src/components/Cell/Cell.vue
@@ -141,6 +141,10 @@ export default {
     transition: none;
     background-color: #20416d;
   }
+
+  & .fa-icon {
+    margin: -0.2em 0;
+  }
 }
 
 .title {

--- a/packages/head-up/src/components/HeadUp/HeadUp.test.js
+++ b/packages/head-up/src/components/HeadUp/HeadUp.test.js
@@ -1,6 +1,7 @@
 import { merge } from 'lodash';
 import ally from 'ally.js';
 import ShortKey from 'vue-shortkey';
+import Sentencer from 'sentencer';
 import { createLocalVue, shallowMount, mount } from '@vue/test-utils';
 import Board from '../Board';
 import Cell from '../Cell';
@@ -79,6 +80,7 @@ function mountWithProps(options = {}) {
 beforeEach(() => {
   jest.resetAllMocks();
   Element.prototype.scrollIntoView = scrollIntoViewSpy;
+  Sentencer.make = jest.fn(() => 'new board');
 });
 
 test('render default', () => {
@@ -139,7 +141,8 @@ test('add board in sidebar', () => {
   sidebar.vm.$emit('board:add');
 
   expect(wrapper.vm.state.boards.length).toEqual(4);
-  expect(wrapper.vm.state.boards[0].title).toEqual('Board #4');
+  expect(wrapper.vm.state.boards[0].title).toEqual('new board');
+  expect(wrapper.vm.state.boards[0].id).toEqual('new-board');
 });
 
 describe('remove board in sidebar', () => {

--- a/packages/head-up/src/components/HeadUp/HeadUp.test.js
+++ b/packages/head-up/src/components/HeadUp/HeadUp.test.js
@@ -32,7 +32,7 @@ function mountWithSlot(options = {}) {
       {
         localVue,
         slots: {
-          default: '<Board><Cell title="Cell #1"/></Board>',
+          default: '<Board id="b1"><Cell title="Cell #1"/></Board>',
         },
         stubs: {
           Cell,
@@ -111,13 +111,23 @@ test('render with slot', () => {
   const wrapper = mountWithSlot();
 
   expect(wrapper).toMatchSnapshot();
-  expect(scrollIntoViewSpy).toHaveBeenCalled();
 });
 
 test('render with props', () => {
   const wrapper = mountWithProps();
 
   expect(wrapper).toMatchSnapshot();
+});
+
+test('scroll to activeBoard', () => {
+  const wrapper = mountWithProps();
+
+  wrapper.setData({
+    state: {
+      activeBoardId: '2',
+    },
+  });
+
   expect(scrollIntoViewSpy).toHaveBeenCalled();
 });
 
@@ -141,7 +151,8 @@ describe('remove board in sidebar', () => {
     sidebar.vm.$emit('board:remove', '1');
 
     expect(wrapper.vm.state.boards.length).toEqual(2);
-    expect(wrapper.vm.state.activeBoardIdx).toEqual(0);
+    expect(wrapper.vm.state.activeBoardId).toEqual('2');
+    expect(wrapper.vm.activeBoardIndex).toEqual(0);
   });
 
   test('remove last board in the list', () => {
@@ -150,30 +161,32 @@ describe('remove board in sidebar', () => {
 
     wrapper.setData({
       state: {
-        activeBoardIdx: 2,
+        activeBoardId: '3',
       },
     });
     expect(wrapper.vm.state.boards.length).toEqual(3);
     sidebar.vm.$emit('board:remove', '3');
 
     expect(wrapper.vm.state.boards.length).toEqual(2);
-    expect(wrapper.vm.state.activeBoardIdx).toEqual(1);
+    expect(wrapper.vm.state.activeBoardId).toEqual('2');
+    expect(wrapper.vm.activeBoardIndex).toEqual(1);
   });
 
-  test('remove board before active', () => {
+  test('remove board preceding the active one', () => {
     const wrapper = mountWithProps();
     const sidebar = wrapper.find(Sidebar);
 
     wrapper.setData({
       state: {
-        activeBoardIdx: 1,
+        activeBoardId: '2',
       },
     });
     expect(wrapper.vm.state.boards.length).toEqual(3);
+    expect(wrapper.vm.activeBoardIndex).toEqual(1);
     sidebar.vm.$emit('board:remove', '1');
 
     expect(wrapper.vm.state.boards.length).toEqual(2);
-    expect(wrapper.vm.state.activeBoardIdx).toEqual(0);
+    expect(wrapper.vm.activeBoardIndex).toEqual(0);
   });
 });
 
@@ -264,7 +277,7 @@ describe('persist changes', () => {
   test('enabled persistence', () => {
     wrapper.setData({
       state: {
-        activeBoardIdx: 1,
+        activeBoardId: '2',
       },
     });
 
@@ -287,7 +300,7 @@ describe('persist changes', () => {
     });
     wrapper.setData({
       state: {
-        activeBoardIdx: 1,
+        activeBoardId: '2',
       },
     });
 
@@ -316,35 +329,30 @@ describe('respond to keystrokes', () => {
   });
 
   test('next board', () => {
-    expect(wrapper.vm.state.activeBoardIdx).toEqual(0);
+    expect(wrapper.vm.state.activeBoardId).toEqual('1');
     wrapper.trigger('keydown', {
       key: 'j',
     });
-    expect(wrapper.vm.state.activeBoardIdx).toEqual(1);
+    expect(wrapper.vm.state.activeBoardId).toEqual('2');
     wrapper.trigger('keydown', {
       key: 'j',
     });
     wrapper.trigger('keydown', {
       key: 'j',
     });
-    expect(wrapper.vm.state.activeBoardIdx).toEqual(0);
+    expect(wrapper.vm.state.activeBoardId).toEqual('1');
   });
 
   test('previous board', () => {
-    wrapper.setData({
-      state: {
-        activeBoardIdx: 1,
-      },
-    });
     wrapper.trigger('keydown', {
       key: 'k',
     });
-    expect(wrapper.vm.state.activeBoardIdx).toEqual(0);
+    expect(wrapper.vm.state.activeBoardId).toEqual('3');
 
     wrapper.trigger('keydown', {
       key: 'k',
     });
-    expect(wrapper.vm.state.activeBoardIdx).toEqual(2);
+    expect(wrapper.vm.state.activeBoardId).toEqual('2');
   });
 
   test('toggle sidebar', () => {

--- a/packages/head-up/src/components/HeadUp/HeadUp.vue
+++ b/packages/head-up/src/components/HeadUp/HeadUp.vue
@@ -49,6 +49,7 @@
 
 <script>
 import { get } from 'lodash';
+import Sentencer from 'sentencer';
 import ally from 'ally.js';
 import { serializeSlot } from '../../transformers';
 import ModalDialogue from '../ModalDialogue';
@@ -241,9 +242,10 @@ export default {
       this.state.editMode = false;
     },
     handleAddBoard() {
-      const boardId = `hu-${this.state.boards.length + 1}`;
+      const name = Sentencer.make('{{ adjective }} {{ noun }}');
+      const boardId = name.replace(' ', '-');
       const newBoardTemplate = {
-        title: `Board #${this.boardSummary.length + 1}`,
+        title: name,
         id: boardId,
         editable: true,
         cells: [

--- a/packages/head-up/src/components/HeadUp/HeadUpBoards.test.js
+++ b/packages/head-up/src/components/HeadUp/HeadUpBoards.test.js
@@ -8,13 +8,14 @@ const provideMock = {
 };
 
 const slotContents = `
-  <Board title="Slot board #1">
+  <Board title="Slot board #1" id="b1">
     <Cell title="Cell #1"/>
   </Board>
 `;
 
 const boardsMock = [
   {
+    id: '1',
     title: 'Prop board #1',
     cells: [
       {

--- a/packages/head-up/src/components/HeadUp/__snapshots__/HeadUp.test.js.snap
+++ b/packages/head-up/src/components/HeadUp/__snapshots__/HeadUp.test.js.snap
@@ -4,6 +4,7 @@ exports[`modal dialogues help 1`] = `
 <div class="HeadUp">
   <sidebar-stub visible="true"></sidebar-stub>
   <div class="main">
+    <!---->
     <headupboards-stub boards="">
       <div class="Board">
         <!---->
@@ -33,6 +34,7 @@ exports[`modal dialogues settings 1`] = `
 <div class="HeadUp">
   <sidebar-stub visible="true"></sidebar-stub>
   <div class="main">
+    <!---->
     <headupboards-stub boards="">
       <div class="Board">
         <!---->
@@ -62,6 +64,7 @@ exports[`render default 1`] = `
 <div class="HeadUp">
   <sidebar-stub visible="true"></sidebar-stub>
   <div class="main">
+    <!---->
     <headupboards-stub boards=""></headupboards-stub>
   </div>
   <!---->
@@ -72,6 +75,7 @@ exports[`render in edit mode 1`] = `
 <div class="HeadUp _edit">
   <sidebar-stub visible="true"></sidebar-stub>
   <div class="main">
+    <!---->
     <headupboards-stub boards=""></headupboards-stub>
   </div>
   <!---->
@@ -82,6 +86,7 @@ exports[`render with props 1`] = `
 <div class="HeadUp">
   <sidebar-stub visible="true"></sidebar-stub>
   <div class="main">
+    <!---->
     <div class="HeadUpBoards">
       <div class="Board">
         <!---->
@@ -148,6 +153,7 @@ exports[`render with slot 1`] = `
 <div class="HeadUp">
   <sidebar-stub visible="true"></sidebar-stub>
   <div class="main">
+    <!---->
     <headupboards-stub boards="">
       <div class="Board">
         <!---->
@@ -174,6 +180,7 @@ exports[`render without sidebar 1`] = `
 <div class="HeadUp">
   <!---->
   <div class="main">
+    <!---->
     <headupboards-stub boards=""></headupboards-stub>
   </div>
   <!---->

--- a/packages/head-up/src/components/HelpScreen.vue
+++ b/packages/head-up/src/components/HelpScreen.vue
@@ -26,7 +26,7 @@
     </div>
     <div>
       <dt>Shift &lt;</dt>
-      <dd>Insert settings</dd>
+      <dd>Show settings</dd>
     </div>
   </dl>
 </template>

--- a/packages/head-up/src/components/Sidebar/SidebarBoards.test.js
+++ b/packages/head-up/src/components/Sidebar/SidebarBoards.test.js
@@ -3,12 +3,13 @@ import SidebarBoards from './SidebarBoards';
 
 const boardsMock = [
   {
+    id: '1',
     title: 'Board #1',
     cells: [{ title: 'Cell #1' }, { title: 'Cell #2' }],
   },
   {
+    id: '2',
     title: 'Board #2',
-    id: '1',
     editable: true,
     cells: [{ title: 'Cell #1' }, { title: 'Cell #2' }],
   },
@@ -17,7 +18,7 @@ const boardsMock = [
 const provideMock = {
   isEditing: () => false,
   getBoardSummary: () => [],
-  getActiveBoardIdx: () => 0,
+  getActiveBoardId: () => '1',
 };
 
 test('render default', () => {
@@ -38,12 +39,12 @@ test('render with boards', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
-test('render with active board index', () => {
+test('render to active board id', () => {
   const wrapper = shallowMount(SidebarBoards, {
     provide: {
       ...provideMock,
       getBoardSummary: () => boardsMock,
-      getActiveBoardIdx: () => 1,
+      getActiveBoardId: () => '2',
     },
   });
 
@@ -61,7 +62,7 @@ test('responds to remove board actions', () => {
 
   const removeButton = wrapper.find('.remove-button');
   removeButton.trigger('click');
-  expect(wrapper.emitted('remove')[0]).toEqual(['1']);
+  expect(wrapper.emitted('remove')[0]).toEqual(['2']);
 });
 
 test('responds to board activation', () => {
@@ -74,7 +75,7 @@ test('responds to board activation', () => {
 
   const boards = wrapper.findAll('.board');
   boards.at(0).trigger('click');
-  expect(wrapper.emitted('activate')[0]).toEqual([0]);
+  expect(wrapper.emitted('activate')[0]).toEqual(['1']);
   boards.at(1).trigger('click');
-  expect(wrapper.emitted('activate')[1]).toEqual([1]);
+  expect(wrapper.emitted('activate')[1]).toEqual(['2']);
 });

--- a/packages/head-up/src/components/Sidebar/SidebarBoards.vue
+++ b/packages/head-up/src/components/Sidebar/SidebarBoards.vue
@@ -8,7 +8,7 @@
       <li
         v-for="(board, idx) in boards"
         :key="idx"
-        :class="getBoardListItemClass(board, idx)"
+        :class="getBoardListItemClass(board)"
         :title="getBoardTitle(board)"
         class="list-item"
       >
@@ -25,9 +25,10 @@
         </transition>
         <button
           class="board-button"
-          @click="handleActivateBoard(idx)"
+          @click="handleActivateBoard(board.id)"
         >
           <Board
+            :id="board.id"
             :cells="board.cells"
             is-thumb
             class="board"
@@ -49,8 +50,8 @@ export default {
     Board,
   },
   computed: {
-    activeIdx() {
-      return this.getActiveBoardIdx();
+    activeId() {
+      return this.getActiveBoardId();
     },
     boards() {
       return this.getBoardSummary();
@@ -59,22 +60,22 @@ export default {
       return this.isEditing();
     },
   },
-  inject: ['isEditing', 'getBoardSummary', 'getActiveBoardIdx'],
+  inject: ['isEditing', 'getBoardSummary', 'getActiveBoardId'],
   methods: {
     getBoardTitle(board) {
       return board.title + (board.editable ? '' : ' (read-only)');
     },
-    getBoardListItemClass(item, idx) {
+    getBoardListItemClass(board) {
       return {
-        _active: this.activeIdx > -1 ? idx === this.activeIdx : idx === 0,
-        ['_read-only']: !item.editable,
+        _active: this.activeId === board.id,
+        ['_read-only']: !board.editable,
       };
     },
-    handleRemoveBoard(boardId) {
-      this.$emit('remove', boardId);
+    handleRemoveBoard(board) {
+      this.$emit('remove', board);
     },
-    handleActivateBoard(boardIdx) {
-      this.$emit('activate', boardIdx);
+    handleActivateBoard(board) {
+      this.$emit('activate', board);
     },
   },
 };

--- a/packages/head-up/src/components/Sidebar/__snapshots__/SidebarBoards.test.js.snap
+++ b/packages/head-up/src/components/Sidebar/__snapshots__/SidebarBoards.test.js.snap
@@ -2,18 +2,18 @@
 
 exports[`render default 1`] = `<div class="SidebarBoards"><span tag="ul" name="boardReveal" class="board-list"></span></div>`;
 
-exports[`render with active board index 1`] = `
-<div class="SidebarBoards"><span tag="ul" name="boardReveal" class="board-list"><li title="Board #1 (read-only)" class="list-item _read-only"><!----> <button class="board-button"><board-stub id="" isthumb="true" title="" cells="[object Object],[object Object]" class="board"></board-stub></button> <div class="board-title">
+exports[`render to active board id 1`] = `
+<div class="SidebarBoards"><span tag="ul" name="boardReveal" class="board-list"><li title="Board #1 (read-only)" class="list-item _read-only"><!----> <button class="board-button"><board-stub id="1" isthumb="true" title="" cells="[object Object],[object Object]" class="board"></board-stub></button> <div class="board-title">
         Board #1
-      </div></li><li title="Board #2" class="list-item _active"><!----> <button class="board-button"><board-stub id="" isthumb="true" title="" cells="[object Object],[object Object]" class="board"></board-stub></button> <div class="board-title">
+      </div></li><li title="Board #2" class="list-item _active"><!----> <button class="board-button"><board-stub id="2" isthumb="true" title="" cells="[object Object],[object Object]" class="board"></board-stub></button> <div class="board-title">
         Board #2
       </div></li></span></div>
 `;
 
 exports[`render with boards 1`] = `
-<div class="SidebarBoards"><span tag="ul" name="boardReveal" class="board-list"><li title="Board #1 (read-only)" class="list-item _active _read-only"><!----> <button class="board-button"><board-stub id="" isthumb="true" title="" cells="[object Object],[object Object]" class="board"></board-stub></button> <div class="board-title">
+<div class="SidebarBoards"><span tag="ul" name="boardReveal" class="board-list"><li title="Board #1 (read-only)" class="list-item _active _read-only"><!----> <button class="board-button"><board-stub id="1" isthumb="true" title="" cells="[object Object],[object Object]" class="board"></board-stub></button> <div class="board-title">
         Board #1
-      </div></li><li title="Board #2" class="list-item"><!----> <button class="board-button"><board-stub id="" isthumb="true" title="" cells="[object Object],[object Object]" class="board"></board-stub></button> <div class="board-title">
+      </div></li><li title="Board #2" class="list-item"><!----> <button class="board-button"><board-stub id="2" isthumb="true" title="" cells="[object Object],[object Object]" class="board"></board-stub></button> <div class="board-title">
         Board #2
       </div></li></span></div>
 `;

--- a/packages/head-up/src/transformers.js
+++ b/packages/head-up/src/transformers.js
@@ -14,6 +14,7 @@ export function serializeSlot(slot) {
   );
 
   return boards.map(slot => ({
+    id: getOption(slot, 'propsData.id'),
     title: getOption(slot, 'propsData.title'),
     editable: false,
     cells: getChildComponents(getOption(slot, 'children')).map(cell => ({


### PR DESCRIPTION
- Improve board activation logic by requiring Board `id` prop and using that to activate boards rather than index. Index was complicating things with the use of generated and using templates to combine boards.
- Display board title briefly when activating board. 